### PR TITLE
fix: fetch types request info should receive an URL

### DIFF
--- a/fetch/@types/index.d.ts
+++ b/fetch/@types/index.d.ts
@@ -116,7 +116,7 @@ declare class Body {
 }
 
 type RequestRedirect = 'error' | 'follow' | 'manual';
-type RequestInfo = string | Body;
+type RequestInfo = string | Body | URL;
 declare class Request extends Body {
 	constructor(input: RequestInfo, init?: RequestInit);
 


### PR DESCRIPTION
Per the spec fetch should receive an URL and jsdocs also say [that](https://github.com/web-std/io/blob/main/fetch/src/index.js#L35)