### PR TITLE
fix: file support for electron renderer

### DIFF
--- a/file/src/file.js
+++ b/file/src/file.js
@@ -1,0 +1,66 @@
+import { Blob } from "./package.js"
+
+/**
+ * @implements {globalThis.File}
+ */
+export const WebFile = class File extends Blob {
+  /**
+   *
+   * @param {BlobPart[]} init
+   * @param {string} name - A USVString representing the file name or the path
+   * to the file.
+   * @param {FilePropertyBag} [options]
+   */
+  constructor(
+    init,
+    name = panic(new TypeError("File constructor requires name argument")),
+    options = {}
+  ) {
+    super(init, options)
+    // Per File API spec https://w3c.github.io/FileAPI/#file-constructor
+    // Every "/" character of file name must be replaced with a ":".
+    /** @private */
+    this._name = name
+    // It appears that browser do not follow the spec here.
+    // String(name).replace(/\//g, ":")
+    /** @private */
+    this._lastModified = options.lastModified || Date.now()
+  }
+
+  /**
+   * The name of the file referenced by the File object.
+   * @type {string}
+   */
+  get name() {
+    return this._name
+  }
+
+  /**
+   * The path the URL of the File is relative to.
+   * @type {string}
+   */
+  get webkitRelativePath() {
+    return ""
+  }
+
+  /**
+   * Returns the last modified time of the file, in millisecond since the UNIX
+   * epoch (January 1st, 1970 at Midnight).
+   * @returns {number}
+   */
+  get lastModified() {
+    return this._lastModified
+  }
+
+  get [Symbol.toStringTag]() {
+    return "File"
+  }
+}
+
+/**
+ * @param {*} error
+ * @returns {never}
+ */
+const panic = error => {
+  throw error
+}

--- a/file/src/lib.node.js
+++ b/file/src/lib.node.js
@@ -2,74 +2,13 @@
 "use strict"
 
 import { Blob } from "./package.js"
+import { WebFile } from "./file.js"
 
-/**
- * @implements {globalThis.File}
- */
-const WebFile = class File extends Blob {
-  /**
-   *
-   * @param {BlobPart[]} init
-   * @param {string} name - A USVString representing the file name or the path
-   * to the file.
-   * @param {FilePropertyBag} [options]
-   */
-  constructor(
-    init,
-    name = panic(new TypeError("File constructor requires name argument")),
-    options = {}
-  ) {
-    super(init, options)
-    // Per File API spec https://w3c.github.io/FileAPI/#file-constructor
-    // Every "/" character of file name must be replaced with a ":".
-    /** @private */
-    this._name = name
-    // It appears that browser do not follow the spec here.
-    // String(name).replace(/\//g, ":")
-    /** @private */
-    this._lastModified = options.lastModified || Date.now()
-  }
-
-  /**
-   * The name of the file referenced by the File object.
-   * @type {string}
-   */
-  get name() {
-    return this._name
-  }
-
-  /**
-   * The path the URL of the File is relative to.
-   * @type {string}
-   */
-  get webkitRelativePath() {
-    return ""
-  }
-
-  /**
-   * Returns the last modified time of the file, in millisecond since the UNIX
-   * epoch (January 1st, 1970 at Midnight).
-   * @returns {number}
-   */
-  get lastModified() {
-    return this._lastModified
-  }
-
-  get [Symbol.toStringTag]() {
-    return "File"
-  }
-}
-
-/**
- * @param {*} error
- * @returns {never}
- */
-const panic = error => {
-  throw error
-}
+// Electron-renderer has `XMLHttpRequest` and should get the browser implementation
+// instead of node.
 
 // Marking export as a DOM File object instead of custom class.
 /** @type {typeof globalThis.File} */
-const File = WebFile
+const File = typeof XMLHttpRequest === 'function' ? globalThis.File : WebFile
 
 export { File, Blob }

--- a/file/src/lib.node.js
+++ b/file/src/lib.node.js
@@ -4,11 +4,11 @@
 import { Blob } from "./package.js"
 import { WebFile } from "./file.js"
 
-// Electron-renderer has `XMLHttpRequest` and should get the browser implementation
-// instead of node.
+// Electron-renderer should get the browser implementation instead of node
+// Browser configuration is not enough
 
 // Marking export as a DOM File object instead of custom class.
 /** @type {typeof globalThis.File} */
-const File = typeof XMLHttpRequest === 'function' ? globalThis.File : WebFile
+const File = typeof globalThis.File === 'function' ? globalThis.File : WebFile
 
 export { File, Blob }


### PR DESCRIPTION
Previous PR to fix browser export was not enough. File in electron renderer does not use the browser export and uses Node.js, causing https://github.com/ipfs/js-ipfs/pull/3750 CI job in electron renderer to fail.

I think this is the cleanest solution, I moved the File implementation to a new fail, and add a fallback in Node.js. 

The Blob implementation has the same issue (does not affect my other PR), if you like this solution I can fix Blob in a next PR