### PR TITLE
fix: fetch in cjs runtime

### DIFF
--- a/.github/workflows/fetch.yml
+++ b/.github/workflows/fetch.yml
@@ -72,7 +72,7 @@ jobs:
       - name: Install
         uses: bahmutov/npm-install@v1
 
-      - name: Test
+      - name: Test (ESM)
         run: yarn --cwd ${{matrix.project}} test -- --colors
 
       # upload coverage only once
@@ -81,6 +81,9 @@ jobs:
         if: matrix.node == '14' && matrix.os == 'ubuntu-latest'
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Test (CJS)
+        run: yarn --cwd ${{matrix.project}} test:cjs
   publish:
     name: Publish
     needs:

--- a/blob/package.json
+++ b/blob/package.json
@@ -46,7 +46,7 @@
     "prepare": "npm run build",
     "test:es": "uvu test all.spec.js",
     "test:web": "playwright-test -r uvu test/web.spec.js",
-    "test:cjs": "rimraf dist && npm run build && node dist/test/web.spec.cjs",
+    "test:cjs": "rimraf dist && npm run build && node dist/test/all.spec.cjs",
     "test": "npm run test:es && npm run test:cjs",
     "precommit": "lint-staged"
   },

--- a/fetch/package.json
+++ b/fetch/package.json
@@ -24,12 +24,15 @@
     "node": "^10.17 || >=12.3"
   },
   "scripts": {
-    "build": "rollup -c",
+    "build": "npm run build:cjs && npm run build:types",
     "test": "node --experimental-modules ../node_modules/c8/bin/c8 --reporter=html --reporter=lcov --reporter=text --check-coverage node --experimental-modules ../node_modules/mocha/bin/mocha",
+    "test:cjs": "node ./test/commonjs/test-artifact.js",
     "coverage": "c8 report --reporter=text-lcov | coveralls",
     "typecheck": "tsc --build",
+    "build:types": "tsc --build",
+    "build:cjs": "rollup -c",
     "lint": "xo",
-    "prepublishOnly": "node ./test/commonjs/test-artifact.js && tsc --build"
+    "prepublishOnly": "npm run build"
   },
   "repository": {
     "type": "git",

--- a/fetch/package.json
+++ b/fetch/package.json
@@ -32,7 +32,7 @@
     "build:types": "tsc --build",
     "build:cjs": "rollup -c",
     "lint": "xo",
-    "prepublishOnly": "npm run build"
+    "prepare": "npm run build"
   },
   "repository": {
     "type": "git",

--- a/fetch/package.json
+++ b/fetch/package.json
@@ -79,7 +79,7 @@
     "@web-std/form-data": "^2.1.0",
     "data-uri-to-buffer": "^3.0.1",
     "web-streams-polyfill": "^3.1.1",
-    "@ssttevee/multipart-parser": "^0.1.9"
+    "@web3-storage/multipart-parser": "^1.0.0"
   },
   "esm": {
     "sourceMap": true,

--- a/fetch/src/utils/form-data.js
+++ b/fetch/src/utils/form-data.js
@@ -1,5 +1,5 @@
 import {randomBytes} from 'crypto';
-import { iterateMultipart } from '@ssttevee/multipart-parser'
+import { iterateMultipart } from '@web3-storage/multipart-parser';
 import {isBlob} from './is.js';
 
 const carriage = '\r\n';

--- a/fetch/test/commonjs/test-artifact.js
+++ b/fetch/test/commonjs/test-artifact.js
@@ -1,11 +1,4 @@
 // @ts-nocheck
-/**
- * Rebuild first
- */
-const {execFileSync} = require('child_process');
-
-console.log('Building CommonJS version...');
-execFileSync('npm', ['run', 'build'], {stdio: 'inherit'});
 
 const assert = require('assert');
 const fetch = require('../../');

--- a/file/package.json
+++ b/file/package.json
@@ -50,7 +50,7 @@
     "prepare": "npm run build",
     "test:es": "uvu test all.spec.js",
     "test:web": "playwright-test -r uvu test/web.spec.js",
-    "test:cjs": "rimraf dist && npm run build && node dist/test/web.spec.cjs",
+    "test:cjs": "rimraf dist && npm run build && node dist/test/all.spec.cjs",
     "test": "npm run test:es && npm run test:cjs",
     "precommit": "lint-staged"
   },

--- a/form-data/package.json
+++ b/form-data/package.json
@@ -51,7 +51,7 @@
     "prepare": "npm run build",
     "test:es": "uvu test all.spec.js",
     "test:web": "playwright-test -r uvu test/web.spec.js",
-    "test:cjs": "rimraf dist && npm run build && node dist/test/web.spec.cjs",
+    "test:cjs": "rimraf dist && npm run build && node dist/test/all.spec.cjs",
     "test": "npm run test:es && npm run test:cjs",
     "precommit": "lint-staged"
   },

--- a/package.json
+++ b/package.json
@@ -7,10 +7,11 @@
     "fetch"
   ],
   "scripts": {
-    "prepare": "yarn prepare:blob && yarn prepare:file && yarn prepare:form-data",
+    "prepare": "yarn prepare:blob && yarn prepare:file && yarn prepare:form-data && yarn prepare:fetch",
     "prepare:blob": "yarn --cwd blob prepare",
     "prepare:file": "yarn --cwd file prepare",
     "prepare:form-data": "yarn --cwd form-data prepare",
+    "prepare:fetch": "yarn --cwd fetch prepare",
     "test": "yarn test:blob && yarn test:file && yarn test:form-data && yarn test:fetch",
     "test:blob": "yarn --cwd blob test",
     "test:file": "yarn --cwd file test",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4829,7 +4829,6 @@ readable-stream@^2.0.2, readable-stream@^2.3.3, readable-stream@^2.3.6:
 
 readable-stream@^3.4.0, readable-stream@^3.6.0, "readable-stream@https://registry.npmjs.org/@leichtgewicht/readable-stream/-/readable-stream-3.6.0.tgz":
   version "3.6.0"
-  uid "25682c94346526abc8c8b1ece125b52a7247bb2e"
   resolved "https://registry.npmjs.org/@leichtgewicht/readable-stream/-/readable-stream-3.6.0.tgz#25682c94346526abc8c8b1ece125b52a7247bb2e"
   dependencies:
     browser-util-inspect "^0.2.0"
@@ -5581,7 +5580,6 @@ text-table@^0.2.0:
 
 "through2@https://registry.npmjs.org/@leichtgewicht/through2/-/through2-4.0.2.tgz":
   version "4.0.2"
-  uid ea39512757acd2dab1be4ff1eeb1e43708aa7333
   resolved "https://registry.npmjs.org/@leichtgewicht/through2/-/through2-4.0.2.tgz#ea39512757acd2dab1be4ff1eeb1e43708aa7333"
   dependencies:
     readable-stream "https://registry.npmjs.org/@leichtgewicht/readable-stream/-/readable-stream-3.6.0.tgz"

--- a/yarn.lock
+++ b/yarn.lock
@@ -308,26 +308,6 @@
   resolved "https://registry.yarnpkg.com/@sindresorhus/is/-/is-0.14.0.tgz#9fb3a3cf3132328151f353de4632e01e52102bea"
   integrity sha512-9NET910DNaIPngYnLLPeg+Ogzqsi9uM4mSboU5y6p8S5DzMTVEsJZrawi+BoDNUVBa2DhJqQYUFvMDfgU062LQ==
 
-"@ssttevee/multipart-parser@^0.1.9":
-  version "0.1.9"
-  resolved "https://registry.yarnpkg.com/@ssttevee/multipart-parser/-/multipart-parser-0.1.9.tgz#972a8bffe7204aa3f519f53bc06adee3498df15b"
-  integrity sha512-4GmChu029N2VHdi3SEQMlqTctNRisGoE4HOLAsL7p6nrlWHQ63dqVZ2IsnI0HGizzt2/0MLFNlaF7EFBsuXK2g==
-  dependencies:
-    "@ssttevee/streamsearch" "~0.3.0"
-    "@ssttevee/u8-utils" "~0.1.5"
-
-"@ssttevee/streamsearch@~0.3.0":
-  version "0.3.1"
-  resolved "https://registry.yarnpkg.com/@ssttevee/streamsearch/-/streamsearch-0.3.1.tgz#7f608ce5a1f77a2ac51e84a5c5a128c62f505828"
-  integrity sha512-qL6bEa8R1KlN0rcLVWaLZfS+IVi5nw51FlO54p8PbCkspM5G8ssZhcCNJjnPxSPNz1BqIIt0Rm4tALBilYx1dw==
-  dependencies:
-    "@ssttevee/u8-utils" "~0.1.5"
-
-"@ssttevee/u8-utils@~0.1.5":
-  version "0.1.7"
-  resolved "https://registry.yarnpkg.com/@ssttevee/u8-utils/-/u8-utils-0.1.7.tgz#fb8db35ca9dda860ad3eaf1b557f61e4d43950bc"
-  integrity sha512-bSD+ocJRyAWiav1w7iQmAJ+ao/DJ5cRLcs2VsFDQeA1pODdF8cVZYy69+/irAeEntYoFbKigID/eM389pZ3vMA==
-
 "@szmarczak/http-timer@^1.1.2":
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/@szmarczak/http-timer/-/http-timer-1.1.2.tgz#b1665e2c461a2cd92f4c1bbf50d5454de0d4b421"
@@ -469,6 +449,11 @@
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/@ungap/promise-all-settled/-/promise-all-settled-1.1.2.tgz#aa58042711d6e3275dd37dc597e5d31e8c290a44"
   integrity sha512-sL/cEvJWAnClXw0wHk85/2L0G6Sj8UB0Ctc1TEMbKSsmpRosqhwj9gWgFRZSrBr2f9tiXISwNhCPmlfqUqyb9Q==
+
+"@web3-storage/multipart-parser@^1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@web3-storage/multipart-parser/-/multipart-parser-1.0.0.tgz#6b69dc2a32a5b207ba43e556c25cc136a56659c4"
+  integrity sha512-BEO6al7BYqcnfX15W2cnGR+Q566ACXAT9UQykORCWW80lmkpWsnEob6zJS1ZVBKsSJC8+7vJkHwlp+lXG1UCdw==
 
 "@zxing/text-encoding@0.9.0":
   version "0.9.0"


### PR DESCRIPTION
- #17 introduced a regression in cjs environment
  -  @ssttevee/multipart-parser is incompatible with cjs and fails to load at runtime
- Regression was not caught by test suite
   - most packages were not not exercising fetch with cjs.
   - fetch library itself has no cjs tests

This pull request

1. Updates test suite to exercise fetch in cjs
2. Replaces @ssttevee/multipart-parser with @web3-storage/multipart-parser that works in cjs