### PR TITLE
chore: 🤖 add .npmignore

### DIFF
--- a/packages/blob/.npmignore
+++ b/packages/blob/.npmignore
@@ -1,0 +1,15 @@
+# folders:
+.github
+docs
+coverage
+test
+
+# files:
+.npmignore
+.prettierignore
+rollup.config.js
+tsconfig.json
+.editorconfig
+CHANGELOG.md
+CODE_OF_CONDUCT.md
+example.js

--- a/packages/fetch/.npmignore
+++ b/packages/fetch/.npmignore
@@ -1,0 +1,15 @@
+# folders:
+.github
+docs
+coverage
+test
+
+# files:
+.npmignore
+.prettierignore
+rollup.config.js
+tsconfig.json
+.editorconfig
+CHANGELOG.md
+CODE_OF_CONDUCT.md
+example.js

--- a/packages/file/.npmignore
+++ b/packages/file/.npmignore
@@ -1,0 +1,15 @@
+# folders:
+.github
+docs
+coverage
+test
+
+# files:
+.npmignore
+.prettierignore
+rollup.config.js
+tsconfig.json
+.editorconfig
+CHANGELOG.md
+CODE_OF_CONDUCT.md
+example.js

--- a/packages/form-data/.npmignore
+++ b/packages/form-data/.npmignore
@@ -1,0 +1,15 @@
+# folders:
+.github
+docs
+coverage
+test
+
+# files:
+.npmignore
+.prettierignore
+rollup.config.js
+tsconfig.json
+.editorconfig
+CHANGELOG.md
+CODE_OF_CONDUCT.md
+example.js

--- a/packages/stream/.npmignore
+++ b/packages/stream/.npmignore
@@ -1,0 +1,15 @@
+# folders:
+.github
+docs
+coverage
+test
+
+# files:
+.npmignore
+.prettierignore
+rollup.config.js
+tsconfig.json
+.editorconfig
+CHANGELOG.md
+CODE_OF_CONDUCT.md
+example.js


### PR DESCRIPTION
tsconfigs were accidentally published to npm and they wreck havoc in Remix MDX projects:

![Screenshot 2022-01-06 at 05 23 36](https://user-images.githubusercontent.com/8344688/148334462-5b1b7edd-6fd2-427a-8f1c-be8a675e2811.png)

this PR sets up `.npmignore` to prevent this