### PR TITLE
fix: typescript types

### DIFF
--- a/packages/fetch/package.json
+++ b/packages/fetch/package.json
@@ -99,6 +99,7 @@
   "dependencies": {
     "@web-std/blob": "^3.0.3",
     "@web-std/form-data": "^3.0.2",
+    "@web-std/stream": "^1.0.1",
     "data-uri-to-buffer": "^3.0.1",
     "mrmime": "^1.0.0",
     "@web3-storage/multipart-parser": "^1.0.0"

--- a/packages/fetch/src/package.ts
+++ b/packages/fetch/src/package.ts
@@ -1,4 +1,4 @@
 export const { FormData, Blob } = globalThis
-export * from "@web-std/stream"
+export { ReadableStream } from "@web-std/stream"
 
 

--- a/packages/stream/src/lib.d.ts
+++ b/packages/stream/src/lib.d.ts
@@ -1,18 +1,36 @@
-export const {
-  ReadableStream,
-  ReadableStreamDefaultReader,
+declare var ReadableStreamExport: typeof ReadableStream;
+declare var ReadableStreamDefaultReaderExport: typeof ReadableStreamDefaultReader;
+// @ts-ignore
+declare var ReadableStreamBYOBReaderExport: typeof ReadableStreamBYOBReader;
+// @ts-ignore
+declare var ReadableStreamBYOBRequestExport: typeof ReadableStreamBYOBRequest;
+// @ts-ignore
+declare var ReadableByteStreamControllerExport: typeof ReadableByteStreamController;
+declare var ReadableStreamDefaultControllerExport: typeof ReadableStreamDefaultController;
+declare var TransformStreamExport: typeof TransformStream;
+declare var TransformStreamDefaultControllerExport: typeof TransformStreamDefaultController;
+declare var WritableStreamExport: typeof WritableStream;
+declare var WritableStreamDefaultWriterExport: typeof WritableStreamDefaultWriter;
+declare var WritableStreamDefaultControllerExport: typeof WritableStreamDefaultController;
+declare var ByteLengthQueuingStrategyExport: typeof ByteLengthQueuingStrategy;
+declare var CountQueuingStrategyExport: typeof CountQueuingStrategy;
+declare var TextEncoderStreamExport: typeof TextEncoderStream;
+declare var TextDecoderStreamExport: typeof TextDecoderStream;
 
-  ReadableStreamBYOBReader,
-  ReadableStreamBYOBRequest,
-  ReadableByteStreamController,
-  ReadableStreamDefaultController,
-  TransformStream,
-  TransformStreamDefaultController,
-  WritableStream,
-  WritableStreamDefaultWriter,
-  WritableStreamDefaultController,
-  ByteLengthQueuingStrategy,
-  CountQueuingStrategy,
-  TextEncoderStream,
-  TextDecoderStream,
-} = globalThis
+export {
+  ReadableStreamExport as ReadableStream,
+  ReadableStreamDefaultReaderExport as ReadableStreamDefaultReader,
+  ReadableStreamBYOBReaderExport as ReadableStreamBYOBReader,
+  ReadableStreamBYOBRequestExport as ReadableStreamBYOBRequest,
+  ReadableByteStreamControllerExport as ReadableByteStreamController,
+  ReadableStreamDefaultControllerExport as ReadableStreamDefaultController,
+  TransformStreamExport as TransformStream,
+  TransformStreamDefaultControllerExport as TransformStreamDefaultController,
+  WritableStreamExport as WritableStream,
+  WritableStreamDefaultWriterExport as WritableStreamDefaultWriter,
+  WritableStreamDefaultControllerExport as WritableStreamDefaultController,
+  ByteLengthQueuingStrategyExport as ByteLengthQueuingStrategy,
+  CountQueuingStrategyExport as CountQueuingStrategy,
+  TextEncoderStreamExport as TextEncoderStream,
+  TextDecoderStreamExport as TextDecoderStream,
+};


### PR DESCRIPTION
fix(packages/stream): no initializers in ambient contexts
fix(packages/fetch): only export what's needed so TS doesn't mess up the imports in the output files

Projects that import from web-std currently get some nasty errors such as:

```
node_modules/@web-std/stream/src/lib.d.ts:18:5 - error TS1254: A 'const' initializer in an ambient context must be a string or numeric literal or literal enum reference.

18 } = globalThis
       ~~~~~~~~~~
```

and 

```
node_modules/@web-std/fetch/dist/src/fetch.d.ts:5:32 - error TS2307: Cannot find module 'packages/stream/src/lib.js' or its corresponding type declarations.

5 import { ReadableStream } from "packages/stream/src/lib.js";
                                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

This PR addresses these issues.