### PR TITLE
fix: fetch called on non Window object

### DIFF
--- a/packages/fetch/src/lib.js
+++ b/packages/fetch/src/lib.js
@@ -1,7 +1,4 @@
-
-
 // On the web we just export native fetch implementation
 export { ReadableStream, Blob, FormData  } from './package.js';
 export const { Headers, Request, Response } = globalThis;
-export default globalThis.fetch
-
+export default globalThis.fetch.bind(globalThis)


### PR DESCRIPTION
```
TypeError: 'fetch' called on an object that does not implement interface Window.
```