### PR TITLE
fix(fetch): add HTTPS Agent types to `fetch` & `Request`

### DIFF
--- a/.changeset/polite-poets-enjoy.md
+++ b/.changeset/polite-poets-enjoy.md
@@ -1,0 +1,5 @@
+---
+"@remix-run/web-fetch": minor
+---
+
+expose RequestExtraOptions to fetch & add HTTPs.agent to types

--- a/.changeset/polite-poets-enjoy.md
+++ b/.changeset/polite-poets-enjoy.md
@@ -1,5 +1,5 @@
 ---
-"@remix-run/web-fetch": minor
+"@web-std/fetch": minor
 ---
 
-expose RequestExtraOptions to fetch & add HTTPs.agent to types
+expose `RequestExtraOptions` to `fetch` & add `HTTPs.agent` to types

--- a/packages/fetch/src/fetch.js
+++ b/packages/fetch/src/fetch.js
@@ -33,7 +33,7 @@ const supportedSchemas = new Set(['data:', 'http:', 'https:', 'file:']);
  * Fetch function
  *
  * @param   {string | URL | import('./request').default} url - Absolute url or Request instance
- * @param   {RequestInit} [options_] - Fetch options
+ * @param   {RequestInit & import('./request.js').RequestExtraOptions} [options_] - Fetch options
  * @return  {Promise<import('./response').default>}
  */
 async function fetch(url, options_ = {}) {
@@ -319,9 +319,9 @@ async function fetch(url, options_ = {}) {
 }
 
 /**
- * 
- * @param {import('http').ClientRequest} request 
- * @param {(error:Error) => void} errorCallback 
+ *
+ * @param {import('http').ClientRequest} request
+ * @param {(error:Error) => void} errorCallback
  */
 function fixResponseChunkedTransferBadEnding(request, errorCallback) {
 	/** @type {import('net').Socket} */

--- a/packages/fetch/src/request.js
+++ b/packages/fetch/src/request.js
@@ -49,7 +49,7 @@ const isRequest = object => {
  * @property {number} [highWaterMark]
  * @property {boolean} [insecureHTTPParser]
  * 
- * @typedef {((url:URL) => import('http').Agent) | import('http').Agent} Agent
+ * @typedef {((url:URL) => import('http').Agent | import('https').Agent) | import('http').Agent | import('https').Agent} Agent
  * 
  * @typedef {Object} RequestOptions
  * @property {string} [method]


### PR DESCRIPTION
See @cliffordfajardo's https://github.com/remix-run/web-std-io/pull/18

> ### What is the change?
> * Add typings for `https` agent
> * Add correct typings fetch's `options` param
> 
> ### Why are we making this change?
> * Allow a user to pass `https` to `Request
> * Allow agent & other [`RequestExtraOptions` values](https://github.com/remix-run/web-std-io/blob/main/packages/fetch/src/fetch.js#L184) to be passed to `fetch`
> 
> ### Tests
> Type changes only. Ran npm test inside of `package/fetch` and all tests pass
> 
> <details>
> 
> <summary>Test output for `package/fetch`</summary>
> 
> ```
>  247 passing (4s)
>   4 pending
> 
> -----------------|---------|----------|---------|---------|-----------------------------------------
> File             | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s                       
> -----------------|---------|----------|---------|---------|-----------------------------------------
> All files        |   97.15 |    96.79 |   89.32 |   97.15 |                                         
>  src             |   96.69 |    96.58 |   86.58 |   96.69 |                                         
>   body.js        |   96.97 |    95.45 |   97.36 |   96.97 | 211-212,250-254,263,464-473             
>   fetch.js       |   99.46 |    96.38 |     100 |   99.46 | 117-118                                 
>   headers.js     |   92.73 |    93.75 |   81.81 |   92.73 | 16-24,29-38,95-96                       
>   lib.node.js    |     100 |      100 |     100 |     100 |                                         
>   package.js     |     100 |      100 |     100 |     100 |                                         
>   request.js     |   95.62 |      100 |   56.25 |   95.62 | ...-170,173-174,178-179,183-184,188-189 
>   response.js    |   98.59 |      100 |    90.9 |   98.59 | 59-60                                   
>  src/errors      |     100 |      100 |     100 |     100 |                                         
>   abort-error.js |     100 |      100 |     100 |     100 |                                         
>   base.js        |     100 |      100 |     100 |     100 |                                         
>   fetch-error.js |     100 |      100 |     100 |     100 |                                         
>  src/utils       |   99.27 |     97.4 |     100 |   99.27 |                                         
>   form-data.js   |   98.29 |       92 |     100 |   98.29 | 115-116                                 
>   get-search.js  |     100 |      100 |     100 |     100 |                                         
>   is-redirect.js |     100 |      100 |     100 |     100 |                                         
>   is.js          |     100 |      100 |     100 |     100 |                                         
>   utf8.js        |     100 |      100 |     100 |     100 |                                         
> -----------------|---------|----------|---------|---------|-----------------------------------------
> ```
> </details>

CC/ @alanshaw @Gozala