### PR TITLE
fix(fetch): allow clone of `Request` & `Response` with `null` body

### DIFF
--- a/.changeset/tasty-peas-mate.md
+++ b/.changeset/tasty-peas-mate.md
@@ -1,0 +1,5 @@
+---
+"@remix-run/web-fetch": patch
+---
+
+allow clone of request and responses will null body

--- a/.changeset/tasty-peas-mate.md
+++ b/.changeset/tasty-peas-mate.md
@@ -1,5 +1,5 @@
 ---
-"@remix-run/web-fetch": patch
+"@web-std/fetch": patch
 ---
 
-allow clone of request and responses will null body
+allow clone of request and responses will `null` body

--- a/packages/fetch/src/body.js
+++ b/packages/fetch/src/body.js
@@ -274,7 +274,7 @@ async function consumeBody(data) {
  * Clone body given Res/Req instance
  *
  * @param {Body} instance       Response or Request instance
- * @return {ReadableStream<Uint8Array>}
+ * @return {ReadableStream<Uint8Array> | null}
  */
 export const clone = instance => {
 	const {body} = instance;
@@ -284,7 +284,10 @@ export const clone = instance => {
 		throw new Error('cannot clone body after it is used');
 	}
 
-	// @ts-expect-error - could be null
+	if (!body) {
+		return null;
+	}
+
 	const [left, right] = body.tee();
 	instance[INTERNALS].body = left;
 	return right;

--- a/packages/fetch/test/request.js
+++ b/packages/fetch/test/request.js
@@ -237,6 +237,37 @@ describe('Request', () => {
 		});
 	});
 
+	it('should support clone() method with null body', () => {
+		const url = base;
+
+		const agent = new http.Agent();
+		const {signal} = new AbortController();
+		const request = new Request(url, {
+			method: 'POST',
+			redirect: 'manual',
+			headers: {
+				b: '2'
+			},
+			follow: 3,
+			compress: false,
+			agent,
+			signal
+		});
+		const cl = request.clone();
+		expect(cl.url).to.equal(url);
+		expect(cl.method).to.equal('POST');
+		expect(cl.redirect).to.equal('manual');
+		expect(cl.headers.get('b')).to.equal('2');
+		expect(cl.follow).to.equal(3);
+		expect(cl.compress).to.equal(false);
+		expect(cl.method).to.equal('POST');
+		expect(cl.counter).to.equal(0);
+		expect(cl.agent).to.equal(agent);
+		expect(cl.signal).to.equal(signal);
+		// Clone body should be null
+		expect(cl.body).to.equal(null);
+	});
+
 	it('should support ArrayBuffer as body', () => {
 		const encoder = new TextEncoder();
 		const request = new Request(base, {

--- a/packages/fetch/test/response.js
+++ b/packages/fetch/test/response.js
@@ -129,6 +129,28 @@ describe('Response', () => {
 		});
 	});
 
+	it('should support clone() method with null body', () => {
+		const res = new Response(null, {
+			headers: {
+				a: '1'
+			},
+			url: base,
+			status: 346,
+			statusText: 'production'
+		});
+		const cl = res.clone();
+		expect(cl.headers.get('a')).to.equal('1');
+		expect(cl.url).to.equal(base);
+		expect(cl.status).to.equal(346);
+		expect(cl.statusText).to.equal('production');
+		expect(cl.ok).to.be.false;
+		// Clone body should also be null
+		expect(cl.body).to.equal(null);
+		return cl.text().then(result => {
+			expect(result).to.equal('');
+		});
+	});
+
 	it('should support stream as body', () => {
 		const body = streamFromString('a=1');
 		const res = new Response(body);


### PR DESCRIPTION
See @jacob-ebey's https://github.com/remix-run/web-std-io/pull/20

CC/ @alanshaw @Gozala