### PR TITLE
fix(fetch): `signal` should not be nullable

### DIFF
--- a/.changeset/gentle-fans-invent.md
+++ b/.changeset/gentle-fans-invent.md
@@ -1,0 +1,5 @@
+---
+"@remix-run/web-fetch": patch
+---
+
+Make Request signal handling follow spec: https://fetch.spec.whatwg.org/#ref-for-map-exists%E2%91%A0%E2%91%A3

--- a/.changeset/gentle-fans-invent.md
+++ b/.changeset/gentle-fans-invent.md
@@ -1,5 +1,5 @@
 ---
-"@remix-run/web-fetch": patch
+"@web-std/fetch": patch
 ---
 
-Make Request signal handling follow spec: https://fetch.spec.whatwg.org/#ref-for-map-exists%E2%91%A0%E2%91%A3
+Make `Request` signal handling follow spec: https://fetch.spec.whatwg.org/#ref-for-map-exists%E2%91%A0%E2%91%A3

--- a/packages/fetch/package.json
+++ b/packages/fetch/package.json
@@ -77,7 +77,6 @@
     "@types/mocha": "^9.1.0",
     "@types/chai-as-promised": "^7.1.5",
     "@types/chai-string": "^1.4.2",
-    "abort-controller": "^3.0.0",
     "abortcontroller-polyfill": "^1.7.1",
     "busboy": "^0.3.1",
     "c8": "^7.3.0",
@@ -100,6 +99,7 @@
     "@web-std/blob": "^3.0.3",
     "@web-std/form-data": "^3.0.2",
     "@web-std/stream": "^1.0.1",
+    "abort-controller": "^3.0.0",
     "data-uri-to-buffer": "^3.0.1",
     "mrmime": "^1.0.0",
     "@web3-storage/multipart-parser": "^1.0.0"

--- a/packages/fetch/src/fetch.js
+++ b/packages/fetch/src/fetch.js
@@ -191,7 +191,7 @@ async function fetch(url, options_ = {}) {
 							// Note: We can not use `request.body` because send would have
 							// consumed it already.
 							body: options_.body,
-							signal: request.signal,
+							signal: signal,
 							size: request.size
 						};
 

--- a/packages/fetch/src/request.js
+++ b/packages/fetch/src/request.js
@@ -8,6 +8,7 @@
  */
 
 import {format as formatUrl} from 'url';
+import {AbortController as AbortControllerPolyfill} from 'abort-controller';
 import Headers from './headers.js';
 import Body, {clone, extractContentType, getTotalBytes} from './body.js';
 import {isAbortSignal} from './utils/is.js';
@@ -118,6 +119,15 @@ export default class Request extends Body {
 		// eslint-disable-next-line no-eq-null, eqeqeq
 		if (signal != null && !isAbortSignal(signal)) {
 			throw new TypeError('Expected signal to be an instanceof AbortSignal or EventTarget');
+		}
+		
+		if (!signal) {
+			let AbortControllerConstructor = typeof AbortController != "undefined"
+			? AbortController
+			: AbortControllerPolyfill;
+			/** @type {any} */
+			let newSignal = new AbortControllerConstructor().signal;
+			signal = newSignal;
 		}
 
 		/** @type {RequestState} */

--- a/packages/fetch/test/request.js
+++ b/packages/fetch/test/request.js
@@ -99,7 +99,7 @@ describe('Request', () => {
 		expect(derivedRequest.signal).to.equal(derivedAbortController.signal);
 	});
 
-	it('should allow removing signal on derived Request instances', () => {
+	it('should allow overriding signal on derived Request instances', () => {
 		const parentAbortController = new AbortController();
 		const parentRequest = new Request(`${base}hello`, {
 			signal: parentAbortController.signal
@@ -108,7 +108,8 @@ describe('Request', () => {
 			signal: null
 		});
 		expect(parentRequest.signal).to.equal(parentAbortController.signal);
-		expect(derivedRequest.signal).to.equal(null);
+		expect(derivedRequest.signal).to.not.equal(null);
+		expect(derivedRequest.signal).to.not.equal(parentAbortController.signal);
 	});
 
 	it('should throw error with GET/HEAD requests with body', () => {


### PR DESCRIPTION
See @jacob-ebey's https://github.com/remix-run/web-std-io/pull/22

> Make Request signal handling follow spec: https://fetch.spec.whatwg.org/#ref-for-map-exists%E2%91%A0%E2%91%A3

CC/ @alanshaw @Gozala