### PR TITLE
feat(fetch): support custom `credentials` in `Request`

### DIFF
--- a/.changeset/soft-gorillas-travel.md
+++ b/.changeset/soft-gorillas-travel.md
@@ -1,5 +1,5 @@
 ---
- "@remix-run/web-fetch": patch
- ---
+"@remix-run/web-fetch": patch
+---
  
  Add support for custom "credentials" value. Nothing is done with them at the moment but they pass through for the consumer of the request to access if needed.

--- a/.changeset/soft-gorillas-travel.md
+++ b/.changeset/soft-gorillas-travel.md
@@ -1,0 +1,5 @@
+---
+ "@remix-run/web-fetch": patch
+ ---
+ 
+ Add support for custom "credentials" value. Nothing is done with them at the moment but they pass through for the consumer of the request to access if needed.

--- a/.changeset/soft-gorillas-travel.md
+++ b/.changeset/soft-gorillas-travel.md
@@ -1,5 +1,5 @@
 ---
-"@remix-run/web-fetch": patch
+"@web-std/fetch": feat
 ---
  
- Add support for custom "credentials" value. Nothing is done with them at the moment but they pass through for the consumer of the request to access if needed.
+Add support for custom `credentials` value. Nothing is done with them at the moment but they pass through for the consumer of the request to access if needed.

--- a/packages/fetch/src/request.js
+++ b/packages/fetch/src/request.js
@@ -37,6 +37,7 @@ const isRequest = object => {
  * @property {string} method
  * @property {RequestRedirect} redirect
  * @property {globalThis.Headers} headers
+ * @property {RequestCredentials} credentials
  * @property {URL} parsedURL
  * @property {AbortSignal|null} signal
  * 
@@ -125,6 +126,7 @@ export default class Request extends Body {
 			method,
 			redirect: init.redirect || input.redirect || 'follow',
 			headers,
+			credentials: init.credentials || 'same-origin',
 			parsedURL,
 			signal: signal || null
 		};
@@ -159,7 +161,7 @@ export default class Request extends Body {
 	 */
 
 	get credentials() {
-		return "same-origin"
+		return this[INTERNALS].credentials
 	}
 
 	/**

--- a/packages/fetch/test/request.js
+++ b/packages/fetch/test/request.js
@@ -111,6 +111,16 @@ describe('Request', () => {
 		expect(derivedRequest.signal).to.equal(null);
 	});
 
+	it('should default to "same-origin" as credentials', () => {
+		const request = new Request(base)
+		expect(request.credentials).to.equal('same-origin');
+	})
+
+	it('should respect custom credentials value', () => {
+		expect(new Request(base, { credentials: 'omit'})).to.have.property('credentials', 'omit');
+		expect(new Request(base, { credentials: 'include'})).to.have.property('credentials', 'include');
+	})
+
 	it('should throw error with GET/HEAD requests with body', () => {
 		expect(() => new Request(base, {body: ''}))
 			.to.throw(TypeError);


### PR DESCRIPTION
See @kettanaito's https://github.com/remix-run/web-std-io/pull/21

> ## Motivation
> I'm adopting this polyfill as a part of a large API change in Mock Service Worker to adhere better to the Fetch API specification ([mswjs/interceptors#292](https://github.com/mswjs/interceptors/pull/292), part of [mswjs/msw#1404](https://github.com/mswjs/msw/issues/1404)). While doing so, I've spotted that whenever I construct a `Request` instance, its `credentials` are always set to `same-origin`, ignoring any custom credentials value I may supply in request init.
> 
> It's absolutely possible and allowed to construct a Request instance with any credentials the consumer needs.
> 
> > Context: I'm constructing `Request` instance for an intercepted `XMLHttpRequest` as a part of the `@mswjs/interceptors` library. When dealing with XHR, it controls the credentials behavior with its `withCredentials?: boolean` flag. I must different request credentials values based on that flag to respect the specification and keep the consumer's code consistent.
> 
> ## Changes
> * Adds `credentials` to `RequestState`
> * Updates `Request.credentials` getter to resolve the value from the internal state.
> * Adds missing test suites for request credentials behaviors

CC/ @alanshaw @Gozala