### PR TITLE
fix(fetch): fix memory leak when passing `keepAlive`

### DIFF
--- a/.changeset/giant-taxis-breathe.md
+++ b/.changeset/giant-taxis-breathe.md
@@ -1,0 +1,5 @@
+---
+"@remix-run/web-fetch": patch
+---
+
+Memory leak caused by unregistered listeners. Solution was copied from a node-fetch pr.

--- a/.changeset/giant-taxis-breathe.md
+++ b/.changeset/giant-taxis-breathe.md
@@ -1,5 +1,5 @@
 ---
-"@remix-run/web-fetch": patch
+"@web-std/fetch": patch
 ---
 
 Memory leak caused by unregistered listeners. Solution was copied from a node-fetch pr.

--- a/.changeset/grumpy-steaks-hug.md
+++ b/.changeset/grumpy-steaks-hug.md
@@ -1,5 +1,0 @@
----
-"@remix-run/web-fetch": patch
----
-
-Remove socket listeners if request is aborted

--- a/.changeset/grumpy-steaks-hug.md
+++ b/.changeset/grumpy-steaks-hug.md
@@ -1,0 +1,5 @@
+---
+"@remix-run/web-fetch": patch
+---
+
+Remove socket listeners if request is aborted

--- a/packages/fetch/src/fetch.js
+++ b/packages/fetch/src/fetch.js
@@ -364,10 +364,13 @@ function fixResponseChunkedTransferBadEnding(request, errorCallback) {
 		socket.prependListener('close', onSocketClose);
 		socket.on('data', onData);
 
-		request.on('close', () => {
+		const removeSocketListeners = () => {
 			socket.removeListener('close', onSocketClose);
 			socket.removeListener('data', onData);
-		});
+		}
+
+		request.on('close', removeSocketListeners);
+		request.on('abort', removeSocketListeners);
 	});
 }
 


### PR DESCRIPTION
See @marwan38's https://github.com/remix-run/web-std-io/pull/24 & @donavon's https://github.com/remix-run/web-std-io/pull/29

> This is a direct copy of https://github.com/node-fetch/node-fetch/pull/1474.
> 
> We're having memory leak issues as we're using a http agent with keepAlive options with the fetch used on the remix server.

CC/ @alanshaw @Gozala

---

#77 needs to be merged first