### PR TITLE
chore: promote `types` conditional exports to the top of the list

### DIFF
--- a/.changeset/silver-sloths-lay.md
+++ b/.changeset/silver-sloths-lay.md
@@ -1,0 +1,9 @@
+---
+"@remix-run/web-blob": patch
+"@remix-run/web-fetch": patch
+"@remix-run/web-file": patch
+"@remix-run/web-form-data": patch
+"@remix-run/web-stream": patch
+---
+
+Move types conditional export to the top of the list to align with [the node guidance](https://nodejs.org/api/packages.html#community-conditions-definitions)

--- a/.changeset/silver-sloths-lay.md
+++ b/.changeset/silver-sloths-lay.md
@@ -1,9 +1,9 @@
 ---
-"@remix-run/web-blob": patch
-"@remix-run/web-fetch": patch
-"@remix-run/web-file": patch
-"@remix-run/web-form-data": patch
-"@remix-run/web-stream": patch
+"@web-std/blob": patch
+"@web-std/fetch": patch
+"@web-std/file": patch
+"@web-std/form-data": patch
+"@web-std/stream": patch
 ---
 
 Move types conditional export to the top of the list to align with [the node guidance](https://nodejs.org/api/packages.html#community-conditions-definitions)

--- a/packages/blob/package.json
+++ b/packages/blob/package.json
@@ -18,10 +18,10 @@
   "types": "./dist/src/lib.d.ts",
   "exports": {
     ".": {
+      "types": "./dist/src/lib.d.ts",
       "browser": "./src/lib.js",
       "require": "./dist/src/lib.node.cjs",
-      "import": "./src/lib.node.js",
-      "types": "./dist/src/lib.d.ts"
+      "import": "./src/lib.node.js"
     }
   },
   "dependencies": {

--- a/packages/fetch/package.json
+++ b/packages/fetch/package.json
@@ -9,27 +9,27 @@
   "type": "module",
   "exports": {
     ".": {
+      "types": "./dist/src/lib.node.d.ts",
       "browser": "./src/lib.js",
       "require": "./dist/lib.node.cjs",
-      "import": "./src/lib.node.js",
-      "types": "./dist/src/lib.node.d.ts"
+      "import": "./src/lib.node.js"
     },
     "./package.json": "./package.json",
     "./body": {
-      "import": "./src/body.js",
-      "types": "./dist/src/body.d.ts"
+      "types": "./dist/src/body.d.ts",
+      "import": "./src/body.js"
     },
     "./src/request.js": {
-      "import": "./src/request.js",
-      "types": "./dist/src/request.d.ts"
+      "types": "./dist/src/request.d.ts",
+      "import": "./src/request.js"
     },
     "./src/response.js": {
-      "import": "./src/response.js",
-      "types": "./dist/src/response.d.ts"
+      "types": "./dist/src/response.d.ts",
+      "import": "./src/response.js"
     },
     "./src/headers.js": {
-      "import": "./src/headers.js",
-      "types": "./dist/src/headers.d.ts"
+      "types": "./dist/src/headers.d.ts",
+      "import": "./src/headers.js"
     }
   },
   "files": [

--- a/packages/file/package.json
+++ b/packages/file/package.json
@@ -20,14 +20,15 @@
   "browser": {
     "./src/lib.node.js": "./src/lib.js"
   },
+  "types": "./dist/src/lib.d.ts",
   "exports": {
     ".": {
+      "types": "./dist/src/lib.d.ts",
       "browser": "./src/lib.js",
       "require": "./dist/src/lib.node.cjs",
       "node": "./src/lib.node.js"
     }
   },
-  "types": "./dist/src/lib.d.ts",
   "dependencies": {
     "@web-std/blob": "^3.0.3"
   },

--- a/packages/form-data/package.json
+++ b/packages/form-data/package.json
@@ -15,17 +15,18 @@
   "type": "module",
   "module": "./src/lib.js",
   "main": "./dist/src/lib.node.cjs",
+  "types": "./dist/src/lib.d.ts",
   "browser": {
     "./src/lib.node.js": "./src/lib.js"
   },
   "exports": {
     ".": {
+      "types": "./dist/src/lib.d.ts",
       "browser": "./src/lib.js",
       "require": "./dist/src/lib.node.cjs",
       "import": "./src/lib.node.js"
     }
   },
-  "types": "./dist/src/lib.d.ts",
   "dependencies": {
     "web-encoding": "1.1.5"
   },

--- a/packages/stream/package.json
+++ b/packages/stream/package.json
@@ -23,10 +23,10 @@
   },
   "exports": {
     ".": {
+      "types": "./src/lib.d.ts",
       "browser": "./src/lib.js",
       "require": "./src/stream.cjs",
-      "import": "./src/lib.node.js",
-      "types": "./src/lib.d.ts"
+      "import": "./src/lib.node.js"
     }
   },
   "author": "Irakli Gozalishvili <dev@gozala.io> (https://gozala.io)",


### PR DESCRIPTION
See @brophdawg11's https://github.com/remix-run/web-std-io/pull/38

> `types` conditional exports should always be first: https://nodejs.org/api/packages.html#community-conditions-definitions

CC/ @alanshaw @Gozala