### PR TITLE
fix(fetch): fix `headers.entries`/`values`/`forEach` iteration for `Set-Cookie` headers

### DIFF
--- a/.changeset/good-badgers-sleep.md
+++ b/.changeset/good-badgers-sleep.md
@@ -1,0 +1,5 @@
+---
+"@remix-run/web-fetch": patch
+---
+
+Fix `headers.entries`/`values`/`forEach` iteration for `Set-Cookie` headers

--- a/.changeset/good-badgers-sleep.md
+++ b/.changeset/good-badgers-sleep.md
@@ -1,5 +1,5 @@
 ---
-"@remix-run/web-fetch": patch
+"@web-std/fetch": patch
 ---
 
 Fix `headers.entries`/`values`/`forEach` iteration for `Set-Cookie` headers

--- a/packages/fetch/src/headers.js
+++ b/packages/fetch/src/headers.js
@@ -190,7 +190,14 @@ export default class Headers extends URLSearchParams {
 	 */
 	forEach(callback, thisArg = undefined) {
 		for (const name of this.keys()) {
-			Reflect.apply(callback, thisArg, [this.get(name), name, this]);
+			if (name.toLowerCase() === 'set-cookie') {
+				let cookies = this.getAll(name);
+				while (cookies.length > 0) {
+					Reflect.apply(callback, thisArg, [cookies.shift(), name, this])
+				}
+			} else {
+				Reflect.apply(callback, thisArg, [this.get(name), name, this]);
+			}
 		}
 	}
 
@@ -199,7 +206,14 @@ export default class Headers extends URLSearchParams {
 	 */
 	* values() {
 		for (const name of this.keys()) {
-			yield /** @type {string} */(this.get(name));
+			if (name.toLowerCase() === 'set-cookie') {
+				let cookies = this.getAll(name);
+				while (cookies.length > 0) {
+					yield /** @type {string} */(cookies.shift());
+				}
+			} else {
+				yield /** @type {string} */(this.get(name));
+			}
 		}
 	}
 
@@ -208,7 +222,14 @@ export default class Headers extends URLSearchParams {
 	 */
 	* entries() {
 		for (const name of this.keys()) {
-			yield [name, /** @type {string} */(this.get(name))];
+			if (name.toLowerCase() === 'set-cookie') {
+				let cookies = this.getAll(name);
+				while (cookies.length > 0) {
+					yield [name, /** @type {string} */(cookies.shift())];
+				}
+			} else {
+				yield [name, /** @type {string} */(this.get(name))];
+			}
 		}
 	}
 

--- a/packages/fetch/test/headers.js
+++ b/packages/fetch/test/headers.js
@@ -69,6 +69,26 @@ describe('Headers', () => {
 		expect({key: 'content-type', value: 'text/html', object: headers}).to.deep.equal(results[1]);
 	});
 
+	it('should allow iterating through multiple set-cookie headers with forEach', () => {
+		let headers = new Headers([
+			['a', '1'],
+			['Set-Cookie', 'b=2']
+		]);
+		headers.append('Set-Cookie', 'c=3');
+		expect(headers.entries()).to.be.iterable;
+
+		const results = [];
+		headers.forEach((value, key, object) => {
+			results.push({value, key, object});
+		});
+
+		expect(results).to.deep.equal([
+			{ value: '1', key: 'a', object: headers },
+			{ value: 'b=2', key: 'set-cookie', object: headers },
+			{ value: 'c=3', key: 'set-cookie', object: headers },
+    ]);
+	})
+
 	it('should set "this" to undefined by default on forEach', () => {
 		const headers = new Headers({Accept: 'application/json'});
 		headers.forEach(function () {
@@ -103,7 +123,24 @@ describe('Headers', () => {
 			['b', '2, 3'],
 			['c', '4']
 		]);
+
 	});
+
+	it('should allow iterating through multiple set-cookie headers with for-of loop', () => {
+		let headers = new Headers([
+			['a', '1'],
+			['Set-Cookie', 'b=2']
+		]);
+		headers.append('Set-Cookie', 'c=3');
+		expect(headers.entries()).to.be.iterable;
+
+		const result = [];
+		for (const pair of headers) {
+			result.push(pair);
+		}
+
+		expect(result).to.deep.equal([['a', '1'], ['set-cookie', 'b=2'], ['set-cookie', 'c=3']]);
+	})
 
 	it('should allow iterating through all headers with entries()', () => {
 		const headers = new Headers([
@@ -120,6 +157,16 @@ describe('Headers', () => {
 				['c', '4']
 			]);
 	});
+
+	it('should allow iterating through multiple set-cookie headers with entries()', ()=> {
+		let headers = new Headers([
+			['a', '1'],
+			['Set-Cookie', 'b=2']
+		]);
+		headers.append('Set-Cookie', 'c=3');
+		expect(headers.entries()).to.be.iterable
+			.and.to.deep.iterate.over([['a', '1'], ['set-cookie', 'b=2'], ['set-cookie', 'c=3']]);
+	})
 
 	it('should allow iterating through all headers with keys()', () => {
 		const headers = new Headers([
@@ -144,6 +191,16 @@ describe('Headers', () => {
 		expect(headers.values()).to.be.iterable
 			.and.to.iterate.over(['1', '2, 3', '4']);
 	});
+
+	it('should allow iterating through multiple set-cookie headers with values()', ()=> {
+		let headers = new Headers([
+			['a', '1'],
+			['Set-Cookie', 'b=2']
+		]);
+		headers.append('Set-Cookie', 'c=3');
+		expect(headers.values()).to.be.iterable
+			.and.to.iterate.over(['1', 'b=2', 'c=3']);
+	})
 
 	it('should reject illegal header', () => {
 		const headers = new Headers();


### PR DESCRIPTION
See @brophdawg11's https://github.com/remix-run/web-std-io/pull/39

> It looks like the `headers.entries`/`headers.values`/`headers.forEach` logic we inherited when we forked isn't quite spec compliant when it comes to the `Set-Cookie` header. Our current implementation blindly returns `this.get(headerName)` in these iterators which concatenates multiple values, but `Set-Cookie` is special and should instead treat each value as a standalone entry (internally via looping over `getAll`).
> 
> Notice how in these examples, the custom header values are combined and comma-delimited, but `Set-Cookie` is not.
> 
> Here's this behavior in Chrome:
> 
> <img alt="Screenshot 2023-08-14 at 4 31 19 PM" width="494" src="https://user-images.githubusercontent.com/1609022/260565815-684865ef-6c43-48a2-8e69-b27d3759ece6.png">
> And in node v18:
> 
> ```
> Welcome to Node.js v18.17.0.
> Type ".help" for more information.
> > let headers = new Headers([['X-Custom', '1'],['Set-Cookie', 'a=1']]);
> > headers.append('X-Custom', '2');
> > headers.append('Set-Cookie', 'b=2');
> 
> > JSON.stringify(Array.from(headers.entries()))
> '[["set-cookie","a=1"],["set-cookie","b=2"],["x-custom","1, 2"]]'
> 
> > JSON.stringify(Array.from(headers.values()))
> '["a=1","b=2","1, 2"]'
> 
> > let forEachResults = [];
> > headers.forEach((value, name) => forEachResults.push([name, value]))
> > JSON.stringify(forEachResults)
> '[["set-cookie","a=1"],["set-cookie","b=2"],["x-custom","1, 2"]]'
> 
> > let forOfResults = [];
> > for ([name, value] of headers) { forOfResults.push([name, value]); }
> > JSON.stringify(forOfResults)
> '[["set-cookie","a=1"],["set-cookie","b=2"],["x-custom","1, 2"]]'
> ```
> 
> Also, FWIW, there's also a new [`headers.getSetCookie`](https://developer.mozilla.org/en-US/docs/Web/API/Headers/getSetCookie) method which I think was added to help alleviate some of the confusion - but that's not available until node 19 so it didn't feel right to add that and start relying on it since we'd still be incompatible with node 18 `Response` instances.
> 
> Closes [remix-run/remix#4354](https://github.com/remix-run/remix/issues/4354)
> Relates to [remix-run/remix#7150](https://github.com/remix-run/remix/pull/7150)

CC/ @alanshaw @Gozala