### PR TITLE
fix: Allow subclass methods of Headers to be called correctly

### DIFF
--- a/.changeset/hot-foxes-perform.md
+++ b/.changeset/hot-foxes-perform.md
@@ -1,0 +1,5 @@
+---
+"@web-std/fetch": patch
+---
+
+fix: Allow subclass methods of Headers to be called correctly

--- a/packages/fetch/src/headers.js
+++ b/packages/fetch/src/headers.js
@@ -106,55 +106,6 @@ export default class Headers extends URLSearchParams {
 				[];
 
 		super(result);
-
-		// Returning a Proxy that will lowercase key names, validate parameters and sort keys
-		// eslint-disable-next-line no-constructor-return
-		return new Proxy(this, {
-			get(target, p, receiver) {
-				switch (p) {
-					case 'append':
-					case 'set':
-						/**
-						 * @param {string} name
-						 * @param {string} value
-						 */
-						return (name, value) => {
-							validateHeaderName(name);
-							validateHeaderValue(name, String(value));
-							return URLSearchParams.prototype[p].call(
-								receiver,
-								String(name).toLowerCase(),
-								String(value)
-							);
-						};
-
-					case 'delete':
-					case 'has':
-					case 'getAll':
-						/**
-						 * @param {string} name
-						 */
-						return name => {
-							validateHeaderName(name);
-							// @ts-ignore
-							return URLSearchParams.prototype[p].call(
-								receiver,
-								String(name).toLowerCase()
-							);
-						};
-
-					case 'keys':
-						return () => {
-							target.sort();
-							return new Set(URLSearchParams.prototype.keys.call(target)).keys();
-						};
-
-					default:
-						return Reflect.get(target, p, receiver);
-				}
-			}
-			/* c8 ignore next */
-		});
 	}
 
 	get [Symbol.toStringTag]() {
@@ -184,8 +135,58 @@ export default class Headers extends URLSearchParams {
 	}
 
 	/**
-	 * @param {(value: string, key: string, parent: this) => void} callback 
-	 * @param {any} thisArg 
+	 * @param {string} name
+	 */
+	getAll(name) {
+		validateHeaderName(name);
+		return super.getAll(String(name).toLowerCase());
+	}
+
+	/**
+	 * @param {string} name
+	 * @param {string} value
+	 */
+	append(name, value) {
+		validateHeaderName(name);
+		validateHeaderValue(name, String(value));
+		return super.append(
+			String(name).toLowerCase(),
+			String(value)
+		);
+	}
+
+	/**
+	 * @param {string} name
+	 */
+	delete(name) {
+		validateHeaderName(name);
+		return super.delete(String(name).toLowerCase());
+	}
+
+	/**
+	 * @param {string} name
+	 */
+	has(name) {
+		validateHeaderName(name);
+		return super.has(String(name).toLowerCase());
+	}
+
+	/**
+	 * @param {string} name
+	 * @param {string} value
+	 */
+	set(name, value) {
+		validateHeaderName(name);
+		validateHeaderValue(name, String(value));
+		return super.set(
+			String(name).toLowerCase(),
+			String(value)
+		);
+	}
+
+	/**
+	 * @param {(value: string, key: string, parent: this) => void} callback
+	 * @param {any} thisArg
 	 * @returns {void}
 	 */
 	forEach(callback, thisArg = undefined) {
@@ -199,6 +200,11 @@ export default class Headers extends URLSearchParams {
 				Reflect.apply(callback, thisArg, [this.get(name), name, this]);
 			}
 		}
+	}
+
+	keys() {
+		this.sort();
+		return new Set(super.keys()).keys();
 	}
 
 	/**
@@ -274,7 +280,18 @@ export default class Headers extends URLSearchParams {
  */
 Object.defineProperties(
 	Headers.prototype,
-	['get', 'entries', 'forEach', 'values'].reduce((result, property) => {
+	[
+		'append',
+		'delete',
+		'entries',
+		'forEach',
+		'get',
+		'getAll',
+		'has',
+		'keys',
+		'set',
+		'values'
+	].reduce((result, property) => {
 		result[property] = {enumerable: true};
 		return result;
 	}, /** @type {Record<string, {enumerable:true}>} */ ({}))

--- a/packages/fetch/test/headers.js
+++ b/packages/fetch/test/headers.js
@@ -334,4 +334,34 @@ describe('Headers', () => {
 		// eslint-disable-next-line quotes
 		expect(util.format(headers)).to.equal("{ a: [ '1', '3' ], b: '2', host: 'thehost' }");
 	});
+
+	it('should have the correct prototype chain', () => {
+		const headers = new Headers();
+
+		expect(headers).to.be.instanceOf(Headers);
+		expect(Object.getPrototypeOf(headers)).to.equal(Headers.prototype);
+	});
+
+	it('should have the correct prototype chain when extended', () => {
+		class MyHeaders extends Headers {}
+
+		const headers = new MyHeaders();
+
+		expect(headers).to.be.instanceOf(MyHeaders);
+		expect(headers).to.be.instanceOf(Headers);
+		expect(Object.getPrototypeOf(headers)).to.equal(MyHeaders.prototype);
+	});
+
+	it('should call the method of the subclass', () => {
+		class MyHeaders extends Headers {
+			append(_name, _value) {
+				return 'subclass method called';
+			}
+		}
+
+		const headers = new MyHeaders();
+		const result = headers.append('Content-Type', 'application/json');
+
+		expect(result).to.equal('subclass method called');
+	});
 });


### PR DESCRIPTION
This PR fixes an issue where subclass methods of `Headers` were not being called correctly.

### Problem

When a class extends `Headers`, the subclass's methods (like `append`) were not accessible or called properly. This was caused by the `Proxy` instance in the `Headers` constructor, which intercepted method calls and directed them to the `URLSearchParams` prototype, bypassing any overrides defined in subclasses.

### Solution

* Removed the `Proxy` from the constructor.
* Re-implemented the proxied methods in the `Headers` class to maintain the expected behavior and allowing overrides by subclasses.