### PR TITLE
fix(CI): stop testing on Node 14

### DIFF
--- a/.github/workflows/blob.yml
+++ b/.github/workflows/blob.yml
@@ -17,6 +17,7 @@ jobs:
     name: Typecheck
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         node-version:
           - 16
@@ -42,9 +43,9 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     strategy:
+      fail-fast: false
       matrix:
         node-version:
-          - 14
           - 16
         os:
           - ubuntu-latest

--- a/.github/workflows/fetch.yml
+++ b/.github/workflows/fetch.yml
@@ -18,6 +18,7 @@ jobs:
     name: Typecheck
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         node-version:
           - 16
@@ -44,9 +45,9 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     strategy:
+      fail-fast: false
       matrix:
         node-version:
-          - 14
           - 16
         os:
           - ubuntu-latest
@@ -54,12 +55,6 @@ jobs:
           - macos-latest
         project:
           - fetch
-        exclude:
-          - os: windows-latest
-            node-version: 14
-          # On macOS, run tests with only the LTS environments.
-          - os: macos-latest
-            node-version: 14
 
     steps:
       - uses: actions/checkout@v2
@@ -74,13 +69,6 @@ jobs:
 
       - name: Test (ESM)
         run: yarn --cwd packages/${{matrix.project}} test -- --colors
-
-      # upload coverage only once
-      - name: Coveralls
-        uses: coverallsapp/github-action@master
-        if: matrix.node == '14' && matrix.os == 'ubuntu-latest'
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Test (CJS)
         run: yarn --cwd packages/${{matrix.project}} test:cjs

--- a/.github/workflows/file.yml
+++ b/.github/workflows/file.yml
@@ -17,6 +17,7 @@ jobs:
     name: Typecheck
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         node-version:
           - 16
@@ -42,9 +43,9 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     strategy:
+      fail-fast: false
       matrix:
         node-version:
-          - 14
           - 16
         os:
           - ubuntu-latest

--- a/.github/workflows/form-data.yml
+++ b/.github/workflows/form-data.yml
@@ -18,6 +18,7 @@ jobs:
     name: Typecheck
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         node-version:
           - 16
@@ -43,9 +44,9 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     strategy:
+      fail-fast: false
       matrix:
         node-version:
-          - 14
           - 16
         os:
           - ubuntu-latest

--- a/.github/workflows/stream.yml
+++ b/.github/workflows/stream.yml
@@ -17,6 +17,7 @@ jobs:
     name: Typecheck
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         node-version:
           - 16
@@ -43,9 +44,9 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     strategy:
+      fail-fast: false
       matrix:
         node-version:
-          - 14
           - 16
         os:
           - ubuntu-latest
@@ -76,6 +77,7 @@ jobs:
     runs-on: ubuntu-latest
 
     strategy:
+      fail-fast: false
       matrix:
         node-version:
           - 16


### PR DESCRIPTION
Same problem as fixed in https://github.com/remix-run/web-std-io/pull/66

> CI is failing due to Node 14 tests

https://github.com/web-std/io/actions/runs/14303961236/job/40083578956