### PR TITLE
fix: export CJS version for browser

### DIFF
--- a/.changeset/afraid-coats-rescue.md
+++ b/.changeset/afraid-coats-rescue.md
@@ -1,0 +1,9 @@
+---
+"@web-std/blob": minor
+"@web-std/fetch": minor
+"@web-std/file": minor
+"@web-std/form-data": minor
+"@web-std/stream": minor
+---
+
+Export CJS version for browser

--- a/.github/workflows/blob.yml
+++ b/.github/workflows/blob.yml
@@ -17,6 +17,7 @@ jobs:
     name: Typecheck
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         node-version:
           - 16
@@ -42,9 +43,9 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     strategy:
+      fail-fast: false
       matrix:
         node-version:
-          - 14
           - 16
         os:
           - ubuntu-latest

--- a/.github/workflows/fetch.yml
+++ b/.github/workflows/fetch.yml
@@ -18,6 +18,7 @@ jobs:
     name: Typecheck
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         node-version:
           - 16
@@ -44,9 +45,9 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     strategy:
+      fail-fast: false
       matrix:
         node-version:
-          - 14
           - 16
         os:
           - ubuntu-latest
@@ -54,12 +55,6 @@ jobs:
           - macos-latest
         project:
           - fetch
-        exclude:
-          - os: windows-latest
-            node-version: 14
-          # On macOS, run tests with only the LTS environments.
-          - os: macos-latest
-            node-version: 14
 
     steps:
       - uses: actions/checkout@v2
@@ -74,13 +69,6 @@ jobs:
 
       - name: Test (ESM)
         run: yarn --cwd packages/${{matrix.project}} test -- --colors
-
-      # upload coverage only once
-      - name: Coveralls
-        uses: coverallsapp/github-action@master
-        if: matrix.node == '14' && matrix.os == 'ubuntu-latest'
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Test (CJS)
         run: yarn --cwd packages/${{matrix.project}} test:cjs

--- a/.github/workflows/file.yml
+++ b/.github/workflows/file.yml
@@ -17,6 +17,7 @@ jobs:
     name: Typecheck
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         node-version:
           - 16
@@ -42,9 +43,9 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     strategy:
+      fail-fast: false
       matrix:
         node-version:
-          - 14
           - 16
         os:
           - ubuntu-latest

--- a/.github/workflows/form-data.yml
+++ b/.github/workflows/form-data.yml
@@ -18,6 +18,7 @@ jobs:
     name: Typecheck
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         node-version:
           - 16
@@ -43,9 +44,9 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     strategy:
+      fail-fast: false
       matrix:
         node-version:
-          - 14
           - 16
         os:
           - ubuntu-latest

--- a/.github/workflows/stream.yml
+++ b/.github/workflows/stream.yml
@@ -17,6 +17,7 @@ jobs:
     name: Typecheck
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         node-version:
           - 16
@@ -43,9 +44,9 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     strategy:
+      fail-fast: false
       matrix:
         node-version:
-          - 14
           - 16
         os:
           - ubuntu-latest
@@ -76,6 +77,7 @@ jobs:
     runs-on: ubuntu-latest
 
     strategy:
+      fail-fast: false
       matrix:
         node-version:
           - 16

--- a/packages/blob/package.json
+++ b/packages/blob/package.json
@@ -19,7 +19,10 @@
   "exports": {
     ".": {
       "types": "./dist/src/lib.d.ts",
-      "browser": "./src/lib.js",
+      "browser": {
+        "require": "./dist/src/lib.cjs",
+        "import": "./src/lib.js"
+      },
       "require": "./dist/src/lib.node.cjs",
       "import": "./src/lib.node.js"
     }

--- a/packages/fetch/package.json
+++ b/packages/fetch/package.json
@@ -10,7 +10,10 @@
   "exports": {
     ".": {
       "types": "./dist/src/lib.node.d.ts",
-      "browser": "./src/lib.js",
+      "browser": {
+        "require": "./dist/lib.cjs",
+        "import": "./src/lib.js"
+      },
       "require": "./dist/lib.node.cjs",
       "import": "./src/lib.node.js"
     },

--- a/packages/fetch/rollup.config.js
+++ b/packages/fetch/rollup.config.js
@@ -1,18 +1,35 @@
 import {builtinModules} from 'module';
 import {dependencies} from './package.json';
 
-export default {
-	input: 'src/lib.node.js',
-	output: {
-		file: 'dist/lib.node.cjs',
-		format: 'cjs',
-		esModule: false,
-		interop: false,
-		sourcemap: true,
-		preferConst: true,
-		exports: 'named',
-		// https://github.com/rollup/rollup/issues/1961#issuecomment-534977678
-		outro: 'exports = module.exports = Object.assign(fetch, exports);'
+export default [
+	{
+		input: 'src/lib.js',
+		output: {
+			file: 'dist/lib.cjs',
+			format: 'cjs',
+			esModule: false,
+			interop: false,
+			sourcemap: true,
+			preferConst: true,
+			exports: 'named',
+			// https://github.com/rollup/rollup/issues/1961#issuecomment-534977678
+			outro: 'exports = module.exports = Object.assign(fetch, exports);'
+		},
+		external: [...builtinModules, ...Object.keys(dependencies)]
 	},
-	external: [...builtinModules, ...Object.keys(dependencies)]
-};
+	{
+		input: 'src/lib.node.js',
+		output: {
+			file: 'dist/lib.node.cjs',
+			format: 'cjs',
+			esModule: false,
+			interop: false,
+			sourcemap: true,
+			preferConst: true,
+			exports: 'named',
+			// https://github.com/rollup/rollup/issues/1961#issuecomment-534977678
+			outro: 'exports = module.exports = Object.assign(fetch, exports);'
+		},
+		external: [...builtinModules, ...Object.keys(dependencies)]
+	},
+];

--- a/packages/file/package.json
+++ b/packages/file/package.json
@@ -24,7 +24,10 @@
   "exports": {
     ".": {
       "types": "./dist/src/lib.d.ts",
-      "browser": "./src/lib.js",
+      "browser": {
+        "require": "./dist/src/lib.cjs",
+        "import": "./src/lib.js"
+      },
       "require": "./dist/src/lib.node.cjs",
       "node": "./src/lib.node.js"
     }

--- a/packages/form-data/package.json
+++ b/packages/form-data/package.json
@@ -22,7 +22,10 @@
   "exports": {
     ".": {
       "types": "./dist/src/lib.d.ts",
-      "browser": "./src/lib.js",
+      "browser": {
+        "require": "./dist/src/lib.cjs",
+        "import": "./src/lib.js"
+      },
       "require": "./dist/src/lib.node.cjs",
       "import": "./src/lib.node.js"
     }

--- a/packages/stream/package.json
+++ b/packages/stream/package.json
@@ -24,7 +24,10 @@
   "exports": {
     ".": {
       "types": "./src/lib.d.ts",
-      "browser": "./src/lib.js",
+      "browser": {
+        "require": "./src/stream.cjs",
+        "import": "./src/lib.js"
+      },
       "require": "./src/stream.cjs",
       "import": "./src/lib.node.js"
     }


### PR DESCRIPTION
See https://github.com/remix-run/web-std-io/pull/43

> Just like @SimonB did with https://github.com/uuidjs/uuid/pull/616
> 
> This will remove the necessity of having all the packages in `transformIgnorePatterns` in https://github.com/remix-run/remix/pull/7220 or having them in `moduleNameMapper` in  https://github.com/remix-run/react-router/pull/9895

---

#101 needs to be merged first